### PR TITLE
Make Google Drive destination options and folderId optional

### DIFF
--- a/schemas/destinations/googleDriveDestination.yaml
+++ b/schemas/destinations/googleDriveDestination.yaml
@@ -10,9 +10,10 @@
           default: google-drive
           example: google-drive
         options:
-          description: Additional Google Drive configuration and features.
+          description: >-
+            Additional Google Drive configuration and features. If omitted, files are saved to the root of
+            My Drive using the default Shotstack filename.
           $ref: "./googleDriveDestinationOptions.yaml#/GoogleDriveDestinationOptions"
       type: object
       required:
         - provider
-        - options

--- a/schemas/destinations/googleDriveDestinationOptions.yaml
+++ b/schemas/destinations/googleDriveDestinationOptions.yaml
@@ -4,8 +4,9 @@
       properties:
         folderId:
           description: >-
-            The Google Drive folder ID where asset will be stored. The folder ID is required and can be retrieved from
-            the URL when logged in to Google Drive, e.g. <a href="#">https://drive.google.com/drive/u/0/folders/1r-eTY6OLO8tzQRKwMyq-fIrQ_7AJEI6A</a>.
+            The Google Drive folder ID where the asset will be stored. If omitted, the asset is saved to the root of
+            My Drive. The folder ID can be retrieved from the URL when logged in to Google Drive,
+            e.g. <a href="#">https://drive.google.com/drive/u/0/folders/1r-eTY6OLO8tzQRKwMyq-fIrQ_7AJEI6A</a>.
           type: string
           example: 1r-eTY6OLO8tzQRKwMyq-fIrQ_7AJEI6A
         filename:
@@ -15,5 +16,3 @@
             and thumbnail images.
           type: string
           example: my-file
-      required:
-        - folderId


### PR DESCRIPTION
The delivery pipeline already accepts a `google-drive` destination without `options` and saves the file to the root of My Drive (verified against the live integration). The schema required `options.folderId`, rejecting requests the platform handles fine. This relaxes the contract to match actual behaviour and documents the default: no `folderId` → My Drive root, default filename.

Verify: `pnpm build && pnpm test:smoke` — bundled schema shows `required: ["provider"]` for `GoogleDriveDestination`; generated Zod accepts `{"provider": "google-drive"}`.