### PR TITLE
fix: bundler-safe /json barrels

### DIFF
--- a/scripts/generate-json-schema.cjs
+++ b/scripts/generate-json-schema.cjs
@@ -122,14 +122,13 @@ fs.writeFileSync(
 );
 
 // Barrel files so `@shotstack/schemas/json` resolves for both module systems.
-fs.writeFileSync(
-  path.join(OUT_DIR, "index.js"),
-  `import { createRequire } from 'module';\nconst require = createRequire(import.meta.url);\nexport const edit = require('./edit.json');\n`,
-);
-fs.writeFileSync(
-  path.join(OUT_DIR, "index.cjs"),
-  `module.exports = { edit: require('./edit.json') };\n`,
-);
+// Data is inlined as plain JS: JSON require()/import needs runtime support
+// (createRequire breaks when bundlers emit CJS — import.meta.url is undefined;
+// JSON import attributes vary across Node versions). Plain JS modules work
+// everywhere, including esbuild/webpack Lambda bundles.
+const editJs = JSON.stringify(output);
+fs.writeFileSync(path.join(OUT_DIR, "index.js"), `export const edit = ${editJs};\n`);
+fs.writeFileSync(path.join(OUT_DIR, "index.cjs"), `module.exports = { edit: ${editJs} };\n`);
 fs.writeFileSync(
   path.join(OUT_DIR, "index.d.ts"),
   `export declare const edit: Record<string, unknown>;\n`,

--- a/tests/smoke.cjs
+++ b/tests/smoke.cjs
@@ -388,6 +388,19 @@ async function run() {
     assert.ok(typeof mod.edit === "object", "edit export not found");
   });
 
+  console.log("\n--- JSON barrel bundler-safety checks ---\n");
+
+  // Regression: createRequire(import.meta.url) in the ESM barrel crashed
+  // esbuild CJS Lambda bundles (import.meta.url is undefined there). The
+  // barrels must be pure data modules — no runtime module machinery.
+  for (const barrel of ["json-schema/index.js", "json-schema/index.cjs"]) {
+    check(`${barrel} is a pure data module`, () => {
+      const src = fs.readFileSync(path.join(distDir, barrel), "utf8");
+      assert.ok(!src.includes("import.meta"), "contains import.meta");
+      assert.ok(!src.includes("require("), "contains runtime require()");
+    });
+  }
+
   console.log("\n--- JSON Schema validation checks ---\n");
 
   const Ajv2020 = require("ajv/dist/2020");


### PR DESCRIPTION
`dist/json-schema/index.js` used `createRequire(import.meta.url)` to load `edit.json`. When a consumer bundles with esbuild to CJS (the Shotstack MCP Lambda), `import.meta.url` is `undefined` and the module throws at init — the dev MCP server 502'd on every request.

**Fix:** both barrels now inline the schema as plain JS data modules — no runtime module machinery, works in ESM, CJS, and any bundler output format.

**Verify:** `pnpm build && pnpm test:smoke` (63 passing, includes new checks that the barrels contain no `import.meta`/runtime `require()`); or bundle `import {edit} from '@shotstack/schemas/json'` with esbuild `--format=cjs` and run it.