### PR TITLE
feat(schemas): add italic font style to rich-text and rich-caption fonts

### DIFF
--- a/schemas/richcaptionproperties.yaml
+++ b/schemas/richcaptionproperties.yaml
@@ -132,6 +132,14 @@ RichCaptionFont:
         The weight of the font. Can be a number (100-900) or a string ('normal', 'bold', etc.).
         100 is lightest, 900 is heaviest (boldest).
       default: "400"
+    style:
+      description: The font style.
+      type: string
+      enum:
+        - normal
+        - italic
+      default: "normal"
+      example: "italic"
     color:
       description: The text color using hexadecimal color notation.
       type: string

--- a/schemas/richtextproperties.yaml
+++ b/schemas/richtextproperties.yaml
@@ -19,6 +19,14 @@ RichTextFont:
         The weight of the font. Can be a number (100-900) or a string ('normal', 'bold', etc.).
         100 is lightest, 900 is heaviest (boldest).
       default: "400"
+    style:
+      description: The font style.
+      type: string
+      enum:
+        - normal
+        - italic
+      default: "normal"
+      example: "italic"
     color:
       description: The text color using hexadecimal color notation.
       type: string

--- a/tests/smoke.cjs
+++ b/tests/smoke.cjs
@@ -109,17 +109,24 @@ async function run() {
     const result = zodCjs.richTextAssetSchema.parse({
       type: "rich-text",
       text: "Hello world",
-      font: { style: "italic" },
     });
     assert.strictEqual(result.type, "rich-text");
     assert.strictEqual(result.text, "Hello world");
-    assert.strictEqual(result.font.style, "italic");
   });
 
   check("Reject invalid rich-text asset (missing text)", () => {
     assert.throws(() => {
       zodCjs.richTextAssetSchema.parse({ type: "rich-text" });
     });
+  });
+
+  check("Parse rich-text font style italic", () => {
+    const result = zodCjs.richTextAssetSchema.parse({
+      type: "rich-text",
+      text: "Hello world",
+      font: { style: "italic" },
+    });
+    assert.strictEqual(result.font.style, "italic");
   });
 
   check("Reject unsupported rich-text font style", () => {
@@ -150,16 +157,23 @@ async function run() {
     const result = zodCjs.richCaptionAssetSchema.parse({
       type: "rich-caption",
       src: "https://example.com/captions.srt",
-      font: { style: "italic" },
     });
     assert.strictEqual(result.type, "rich-caption");
-    assert.strictEqual(result.font.style, "italic");
   });
 
   check("Reject invalid rich-caption asset (wrong type value)", () => {
     assert.throws(() => {
       zodCjs.richCaptionAssetSchema.parse({ type: "not-a-type", src: 123 });
     });
+  });
+
+  check("Parse rich-caption font style italic", () => {
+    const result = zodCjs.richCaptionAssetSchema.parse({
+      type: "rich-caption",
+      src: "https://example.com/captions.srt",
+      font: { style: "italic" },
+    });
+    assert.strictEqual(result.font.style, "italic");
   });
 
   check("Reject unsupported rich-caption font style", () => {

--- a/tests/smoke.cjs
+++ b/tests/smoke.cjs
@@ -109,14 +109,26 @@ async function run() {
     const result = zodCjs.richTextAssetSchema.parse({
       type: "rich-text",
       text: "Hello world",
+      font: { style: "italic" },
     });
     assert.strictEqual(result.type, "rich-text");
     assert.strictEqual(result.text, "Hello world");
+    assert.strictEqual(result.font.style, "italic");
   });
 
   check("Reject invalid rich-text asset (missing text)", () => {
     assert.throws(() => {
       zodCjs.richTextAssetSchema.parse({ type: "rich-text" });
+    });
+  });
+
+  check("Reject unsupported rich-text font style", () => {
+    assert.throws(() => {
+      zodCjs.richTextAssetSchema.parse({
+        type: "rich-text",
+        text: "Hello world",
+        font: { style: "oblique" },
+      });
     });
   });
 
@@ -138,13 +150,25 @@ async function run() {
     const result = zodCjs.richCaptionAssetSchema.parse({
       type: "rich-caption",
       src: "https://example.com/captions.srt",
+      font: { style: "italic" },
     });
     assert.strictEqual(result.type, "rich-caption");
+    assert.strictEqual(result.font.style, "italic");
   });
 
   check("Reject invalid rich-caption asset (wrong type value)", () => {
     assert.throws(() => {
       zodCjs.richCaptionAssetSchema.parse({ type: "not-a-type", src: 123 });
+    });
+  });
+
+  check("Reject unsupported rich-caption font style", () => {
+    assert.throws(() => {
+      zodCjs.richCaptionAssetSchema.parse({
+        type: "rich-caption",
+        src: "https://example.com/captions.srt",
+        font: { style: "oblique" },
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds `font.style` (`normal` | `italic`) to the rich-text and rich-caption font schemas — the missing italic switch.
- Unblocks requesting italic text on rich-text / rich-caption (previously rejected).

## Scope
- Strict schemas preserved; `style` is the only newly accepted key.
- `RichCaptionActiveFont` and `timeline.fonts` left unchanged.
- Smoke tests cover: italic accepted, invalid style rejected.